### PR TITLE
fix: restrict workflows on forks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,7 @@ env:
   VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
 jobs:
   deploy:
+    if: github.repository == 'afrid18/Stone'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This should fix how forks run actions.
Now forks should not run deployment workflows. 
But preview action will run on forks when a pull 
request is raised on a fork.